### PR TITLE
Provide a better message to the require_one_of error message

### DIFF
--- a/lib/zoom/params.rb
+++ b/lib/zoom/params.rb
@@ -16,7 +16,10 @@ module Zoom
     def require_one_of(*keys)
       required_keys = keys
       keys = find_matching_keys(keys.flatten)
-      raise Zoom::ParameterMissing, required_keys unless keys.any?
+      unless keys.any?
+        message = required_keys.length > 1 ? "You are missing atleast one of #{required_keys}" : required_keys
+        raise Zoom::ParameterMissing, message
+      end
     end
 
     def permit(*filters)

--- a/spec/lib/zoom/params_spec.rb
+++ b/spec/lib/zoom/params_spec.rb
@@ -27,6 +27,10 @@ RSpec.describe Zoom::Params do
       expect { params.require_one_of(:bar) }.to raise_error(Zoom::ParameterMissing, [:bar].to_s)
     end
 
+    it 'does raise an error when there is a missing required keys out of many' do
+      expect { params.require_one_of(:bar, :fooey, :fooa) }.to raise_error(Zoom::ParameterMissing, "You are missing atleast one of #{[:bar, :fooey, :fooa].to_s}")
+    end
+
     it 'does not raise an error when one of the required keys are missing' do
       expect { params.require_one_of(:foo) }.not_to raise_error(Zoom::ParameterMissing)
     end


### PR DESCRIPTION
If you are using an action that has require_one_of then the error message isn't clear if you are missing an attribute. It should really say, your probably missing one of these attributes, this change allows that.